### PR TITLE
Remove compiler key from Travis CI to fix conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-langauge: c
+language: c
 dist: trusty
-
-compiler:
-  - gcc
-  - clang
 
 matrix:
   include:


### PR DESCRIPTION
Travis CI now has an issue when defining generic compilers to build with and specifying specific compilers in a matrix within the same yaml file.

This removes the compilers key and values in order to avoid this conflict. Also fixes a typo.